### PR TITLE
fix: memoise generated generic decorator classes and exclude them from subclass discovery

### DIFF
--- a/clean_ioc/core.py
+++ b/clean_ioc/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import abc
 import asyncio
+import functools
 import inspect
 import logging
 import types
@@ -61,7 +62,15 @@ EMPTY = _empty()
 UNKNOWN = _unknown()
 
 
+@functools.cache
 def create_generic_decorator_type(concrete_decorator: type):
+    # Memoised: minting a fresh class per call leaks — dynamically created
+    # classes end up pinned for the life of the process by typing's
+    # parameterisation caches (and, before typetoolbox held its GenericTypeMap
+    # cache weakly, by that too), so every register_generic_decorator call on
+    # a new container grew the heap by thousands of classes. The generated
+    # class is a pure template (never mutated after creation), so one per
+    # concrete decorator serves every container in the process.
     return types.new_class(
         f"__DecoratedGeneric__{concrete_decorator.__name__}",
         (concrete_decorator,),
@@ -2312,7 +2321,12 @@ class Container(Scope):
     ) -> list[str]:
         ids: list[str] = []
 
-        full_type_filter = ~is_abstract & subclass_type_filter
+        # Exclude generated decorator template classes (same exclusion as
+        # register_generic_decorator): without it, a process that builds more
+        # than one container rediscovers an earlier build's
+        # __DecoratedGeneric__* classes as implementations and ends up
+        # decorating the decorator, recursing at resolve time.
+        full_type_filter = ~is_abstract & ~name_starts_with("__DecoratedGeneric__") & subclass_type_filter
         subclasses = get_subclasses(generic_service_type, filter=full_type_filter)
         for subclass in subclasses:
             target_generic_base = self._get_target_generic_base(generic_service_type, subclass)

--- a/tests/test_complex_dependencies.py
+++ b/tests/test_complex_dependencies.py
@@ -800,3 +800,50 @@ def test_can_register_a_generic_type_that_has_been_dynamically_created_with_a_ge
     assert isinstance(instance, MyClass)
     assert isinstance(instance.value, A)
     assert isinstance(instance.dependency, MyDepedency)
+
+
+def test_generic_decorator_type_is_memoised_across_containers():
+    """Repeated container builds must not mint fresh decorator classes.
+
+    create_generic_decorator_type used to call types.new_class on every
+    invocation; each new class was then pinned for the life of the process by
+    typing's parameterisation caches, so applications that build a container
+    per test/request leaked thousands of classes per build.
+    """
+    from clean_ioc.core import create_generic_decorator_type
+
+    TMessage = TypeVar("TMessage")
+
+    class MessageA:
+        pass
+
+    class MessageHandler(Generic[TMessage]):
+        def handle(self, message: TMessage):
+            pass
+
+    class AHandler(MessageHandler[MessageA]):
+        pass
+
+    class LoggingDecorator(MessageHandler[TMessage], Generic[TMessage]):
+        def __init__(self, child: MessageHandler[TMessage]):
+            self.child = child
+
+        def handle(self, message: TMessage):
+            self.child.handle(message)
+
+    def build_container() -> Container:
+        container = Container()
+        container.register_generic_subclasses(MessageHandler)
+        container.register_generic_decorator(MessageHandler, LoggingDecorator, decorated_arg="child")
+        return container
+
+    handler_1 = build_container().resolve(MessageHandler[MessageA])  # type: ignore
+    handler_2 = build_container().resolve(MessageHandler[MessageA])  # type: ignore
+
+    assert handler_1 is not handler_2
+    assert type(handler_1) is type(handler_2)
+    assert isinstance(handler_1, LoggingDecorator)
+    assert isinstance(handler_1.child, AHandler)  # type: ignore[attr-defined]
+
+    specialisation = LoggingDecorator[MessageA]
+    assert create_generic_decorator_type(specialisation) is create_generic_decorator_type(specialisation)


### PR DESCRIPTION
## Problem 1: unbounded class leak

`create_generic_decorator_type` mints a fresh class via `types.new_class` on every call. Each generated class is then pinned for the life of the process by `typing`'s parameterisation caches (any `Generic[GeneratedClass]` alias lands in the unbounded `_tp_cache`), so applications that build a container per test or per request leak unboundedly.

Measured in a large FastAPI service's test suite (each test boots a DI container): **~318k retained classes / ~530MB over 30 tests**, with the resulting multi-GB heap stalling pytest session teardown for minutes in CI — gc passes and interpreter finalization are O(heap).

**Fix:** the generated class is a pure template (never mutated after creation), so memoise it per concrete decorator with `functools.cache`. One class per distinct concrete decorator serves every container in the process.

## Problem 2: cross-container self-decoration (pre-existing, exposed by the regression test)

`register_generic_subclasses` does not exclude `__DecoratedGeneric__*` classes the way `register_generic_decorator` does. When a second container is built in the same process, `get_subclasses` rediscovers the earlier build's generated classes (alive via the caches above — memoised or not) and registers them as *implementations*; resolving then decorates the decorator and hits `RecursionError` in `_Registry.get_registrations`. Minimal repro is exactly the new test: build two containers over the same `register_generic_subclasses` + `register_generic_decorator` setup and resolve from each.

**Fix:** apply the same `~name_starts_with("__DecoratedGeneric__")` exclusion in `register_generic_subclasses`.

## Test

`test_generic_decorator_type_is_memoised_across_containers` covers both: two independently built containers resolve through the *same* memoised template class, wiring stays correct (decorator wraps the real handler), and `create_generic_decorator_type` is identity-stable per specialisation. Full suite passes (119 passed).

Related: peter-daly/typetoolbox#6 fixes the third leg of this leak (GenericTypeMap's strong instance cache).