### PR TITLE
Add a resolution benchmark suite

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,9 +29,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --group bench
 
-      # The base revision is measured with the benchmark code from this pull
-      # request, so the only difference between the two runs is library code.
-      - name: Build a base checkout
+      - name: Find the base revision
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
@@ -40,16 +38,17 @@ jobs:
           git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
           BASE=$(git merge-base HEAD "refs/remotes/origin/$BASE_REF")
           echo "Base revision: $BASE"
-          git worktree add ../base "$BASE"
-          cp -R benchmarks pyproject.toml uv.lock ../base/
+          echo "BASE_SHA=$BASE" >> "$GITHUB_ENV"
 
+      # Both revisions are measured in this one checkout, with one virtual
+      # environment and one interpreter. Only the library source is swapped, so
+      # the machine info matches and the two runs stay comparable. The benchmark
+      # code always comes from this pull request.
       - name: Measure the base revision
-        working-directory: ../base
         run: |
-          uv sync --group bench
-          uv run pytest benchmarks --benchmark-only \
-            --benchmark-storage=/tmp/benchmarks \
-            --benchmark-save=base
+          rm -rf clean_ioc
+          git checkout "$BASE_SHA" -- clean_ioc
+          uv run pytest benchmarks --benchmark-only --benchmark-save=base
 
       # min is the comparison metric because it is the least sensitive to the
       # scheduling noise of a shared runner. The threshold is deliberately loose:
@@ -57,8 +56,9 @@ jobs:
       # one. Measure small changes locally with `make bench-compare`.
       - name: Measure this pull request and compare
         run: |
+          rm -rf clean_ioc
+          git checkout HEAD -- clean_ioc
           uv run pytest benchmarks --benchmark-only \
-            --benchmark-storage=/tmp/benchmarks \
             --benchmark-compare=0001_base \
             --benchmark-compare-fail=min:50%
 
@@ -67,5 +67,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
-          path: /tmp/benchmarks
+          path: .benchmarks
           if-no-files-found: warn

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,71 @@
+name: Benchmarks
+
+on:
+  pull_request:
+
+# A later push to the same PR makes an in-flight run pointless.
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Compare against base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --group bench
+
+      # The base revision is measured with the benchmark code from this pull
+      # request, so the only difference between the two runs is library code.
+      - name: Build a base checkout
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # checkout@v4 fetches the pull request ref, not the base branch, so
+          # fetch the base branch before asking for a merge base.
+          git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+          BASE=$(git merge-base HEAD "refs/remotes/origin/$BASE_REF")
+          echo "Base revision: $BASE"
+          git worktree add ../base "$BASE"
+          cp -R benchmarks pyproject.toml uv.lock ../base/
+
+      - name: Measure the base revision
+        working-directory: ../base
+        run: |
+          uv sync --group bench
+          uv run pytest benchmarks --benchmark-only \
+            --benchmark-storage=/tmp/benchmarks \
+            --benchmark-save=base
+
+      # min is the comparison metric because it is the least sensitive to the
+      # scheduling noise of a shared runner. The threshold is deliberately loose:
+      # this job catches a change that makes resolution much slower, not a small
+      # one. Measure small changes locally with `make bench-compare`.
+      - name: Measure this pull request and compare
+        run: |
+          uv run pytest benchmarks --benchmark-only \
+            --benchmark-storage=/tmp/benchmarks \
+            --benchmark-compare=0001_base \
+            --benchmark-compare-fail=min:50%
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: /tmp/benchmarks
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 #vscode settings
 .vscode/
 
+.benchmarks/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,6 @@ repos:
         pass_filenames: false
       - id: unit-tests
         name: unit-tests
-        entry: uv run pytest .
+        entry: uv run pytest
         language: system
         pass_filenames: false

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,67 @@
+# Benchmarks
+
+Resolution benchmarks for the container, built with
+[pytest-benchmark](https://pytest-benchmark.readthedocs.io/).
+
+They are not part of the test suite. `make test` and `make ci` do not run them,
+and `pytest` alone does not collect them, because `testpaths` is set to `tests`.
+
+## Running them
+
+```bash
+make bench           # run every benchmark and print the table
+make bench-save      # record the current revision as the baseline
+make bench-compare   # run again and fail if anything regressed by over 50%
+```
+
+The usual loop for a performance change is `make bench-save` on a clean tree,
+then the change, then `make bench-compare`.
+
+## What each benchmark isolates
+
+Every benchmark registers its graph outside the measured callable, so the
+numbers cover resolution only. The one exception is
+`test_registration_of_many_types`, which measures registration on purpose:
+work moved out of the resolve path has to land somewhere, and that is where.
+
+| Group | Benchmark | Isolates |
+| --- | --- | --- |
+| `single` | `test_transient_with_no_dependencies` | The floor of the resolve path |
+| `single` | `test_singleton_already_cached` | A warm cache hit, so mostly registration lookup |
+| `shape` | `test_deep_transient_graph` | Cost that scales with graph depth |
+| `shape` | `test_wide_transient_graph` | Cost that scales with node count |
+| `shape` | `test_collection_dependency` | `list[T]` resolution over many registrations |
+| `lookup` | `test_filtered_lookup_over_many_registrations` | The registration scan and the filter call per candidate |
+| `lookup` | `test_decorator_chain` | The decorator scan and the extra node per decorator |
+| `scope` | `test_scoped_resolve_in_root_scope` | Baseline for the scoped path |
+| `scope` | `test_scoped_resolve_in_nested_scope` | The added cost of scope nesting |
+| `async` | `test_async_deep_transient_graph` | The separate async resolve path |
+| `registration` | `test_registration_of_many_types` | Constructor introspection at registration |
+
+Graph shapes are generated in `graphs.py` rather than written out, so depth and
+width are parameters instead of constants. The generated classes are real
+classes with real `__init__` signatures, so the container introspects them
+exactly as it would introspect application code.
+
+## Reading the numbers
+
+Compare like with like:
+
+- **Only compare runs from the same machine.** Absolute times mean nothing
+  across machines, and the CI job exists to compare two revisions on one runner,
+  not to publish a number.
+- **Prefer `min` over `mean`.** `min` is the least sensitive to scheduling noise.
+  Both `make bench-compare` and the CI job use it.
+- **Async numbers stand apart.** They include a fixed `run_until_complete`
+  overhead, so compare them only to other async runs.
+
+## In CI
+
+`.github/workflows/benchmarks.yml` runs on every pull request. It measures the
+merge base and the pull request head on the same runner, using the benchmark
+code from the pull request for both, so the only difference between the two runs
+is library code. It fails if any `min` time regresses by more than 50%.
+
+That threshold is loose on purpose. The job is a guard against a change that
+makes resolution much slower. Small differences are noise on a shared runner and
+belong in a local `make bench-compare`.

--- a/benchmarks/graphs.py
+++ b/benchmarks/graphs.py
@@ -1,0 +1,86 @@
+"""Builders for the object graphs the benchmarks resolve.
+
+The shapes here are generated rather than written out by hand so that depth and
+width are parameters of the benchmark instead of constants baked into source.
+Every generated class is a real class with a real ``__init__`` signature, so the
+container introspects it exactly as it would introspect application code.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+_CLASS_TEMPLATE = """\
+class {name}:
+    def __init__(self{params}):
+{body}
+"""
+
+
+def make_class(name: str, dependencies: Mapping[str, Any] | None = None) -> type:
+    """Build a class whose ``__init__`` takes one annotated parameter per dependency.
+
+    Args:
+        name: Class name. Only used in error messages and reprs.
+        dependencies: Parameter name to annotation. Annotations are ``Any``
+            rather than ``type`` because a generic alias such as ``list[T]`` is a
+            valid annotation and is not a class. An empty mapping or ``None``
+            produces a class with no dependencies.
+
+    Returns:
+        The generated class.
+    """
+    dependencies = dependencies or {}
+
+    params = "".join(f", {parameter}" for parameter in dependencies)
+    body = "\n".join(f"        self.{p} = {p}" for p in dependencies) or "        pass"
+    source = _CLASS_TEMPLATE.format(name=name, params=params, body=body)
+
+    namespace: dict[str, object] = {}
+    exec(source, namespace)  # noqa: S102 - generating real classes is the point
+    cls = cast(type, namespace[name])
+
+    # Annotate with the type objects directly. ``get_type_hints`` passes
+    # non-string annotations straight through, so there is nothing to resolve.
+    cls.__init__.__annotations__ = dict(dependencies)
+    return cls
+
+
+def make_chain(depth: int, prefix: str = "Chain") -> list[type]:
+    """Build a chain of classes where each depends on the next.
+
+    Returns:
+        The chain from root to leaf. Index 0 is the root, so resolving it walks
+        the full depth. All of them need registering.
+    """
+    leaf = make_class(f"{prefix}Leaf")
+    chain = [leaf]
+    for level in range(depth - 1):
+        chain.append(make_class(f"{prefix}{level}", {"dep": chain[-1]}))
+    chain.reverse()
+    return chain
+
+
+def make_fan_out(width: int, prefix: str = "Fan") -> tuple[type, list[type]]:
+    """Build one class that depends on ``width`` siblings, none of which nest.
+
+    Returns:
+        The root class, and the sibling classes it depends on. All of them need
+        registering.
+    """
+    siblings = [make_class(f"{prefix}Leaf{index}") for index in range(width)]
+    root = make_class(prefix, {f"dep{index}": cls for index, cls in enumerate(siblings)})
+    return root, siblings
+
+
+def make_implementations(count: int, prefix: str = "Impl") -> tuple[type, list[type]]:
+    """Build a base class and ``count`` subclasses of it.
+
+    Returns:
+        The base class and its subclasses. Used for collection resolution and
+        for filtered lookups over a service type with many registrations.
+    """
+    base = make_class(prefix)
+    implementations: list[type] = [type(f"{prefix}{index}", (base,), {}) for index in range(count)]
+    return base, implementations

--- a/benchmarks/test_resolve.py
+++ b/benchmarks/test_resolve.py
@@ -1,0 +1,194 @@
+"""Resolution benchmarks.
+
+Each benchmark isolates one cost in the resolve path so that a change to that
+path shows up in one place. Registration happens outside the measured callable,
+so the numbers cover resolution only. The exception is
+``test_registration_of_many_types``, which measures registration on purpose.
+
+Run with ``make bench``. Compare two revisions on the same machine with
+``make bench-compare``; numbers from different machines are not comparable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from collections.abc import Iterator
+
+import pytest
+
+from benchmarks.graphs import make_chain, make_class, make_fan_out, make_implementations
+from clean_ioc import Container, Lifespan
+from clean_ioc.registration_filters import with_name
+
+CHAIN_DEPTH = 10
+FAN_OUT_WIDTH = 50
+IMPLEMENTATION_COUNT = 10
+DECORATOR_COUNT = 3
+
+
+@pytest.fixture
+def loop() -> Iterator[asyncio.AbstractEventLoop]:
+    """A loop reused across every round of an async benchmark.
+
+    Loop creation is far more expensive than a resolve, so it must sit outside
+    the measured callable. ``run_until_complete`` still adds a fixed overhead to
+    the async numbers, which is why they are only ever compared to each other.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.close()
+
+
+@pytest.mark.benchmark(group="single")
+def test_transient_with_no_dependencies(benchmark):
+    """Floor for the resolve path: one registration, one lookup, one construction."""
+    a = make_class("A")
+    container = Container()
+    container.register(a, lifespan=Lifespan.transient)
+
+    benchmark(container.resolve, a)
+
+
+@pytest.mark.benchmark(group="single")
+def test_singleton_already_cached(benchmark):
+    """Warm cache hit. Should approach the cost of the registration lookup alone."""
+    a = make_class("A")
+    container = Container()
+    container.register(a, lifespan=Lifespan.singleton)
+    container.resolve(a)
+
+    benchmark(container.resolve, a)
+
+
+@pytest.mark.benchmark(group="shape")
+def test_deep_transient_graph(benchmark):
+    """A ten-level chain. Scales with recursion depth and per-node work."""
+    chain = make_chain(CHAIN_DEPTH)
+    container = Container()
+    for cls in chain:
+        container.register(cls, lifespan=Lifespan.transient)
+
+    benchmark(container.resolve, chain[0])
+
+
+@pytest.mark.benchmark(group="shape")
+def test_wide_transient_graph(benchmark):
+    """One root with fifty flat dependencies. Scales with node count, not depth."""
+    root, siblings = make_fan_out(FAN_OUT_WIDTH)
+    container = Container()
+    container.register(root, lifespan=Lifespan.transient)
+    for cls in siblings:
+        container.register(cls, lifespan=Lifespan.transient)
+
+    benchmark(container.resolve, root)
+
+
+@pytest.mark.benchmark(group="shape")
+def test_collection_dependency(benchmark):
+    """``list[Base]`` with ten registrations behind it."""
+    base, implementations = make_implementations(IMPLEMENTATION_COUNT)
+    # Built through GenericAlias rather than ``list[base]`` so that the
+    # subscript reads as a value expression, not a type expression.
+    root = make_class("CollectionRoot", {"items": types.GenericAlias(list, (base,))})
+
+    container = Container()
+    for implementation in implementations:
+        container.register(base, implementation, lifespan=Lifespan.transient)
+    container.register(root, lifespan=Lifespan.transient)
+
+    benchmark(container.resolve, root)
+
+
+@pytest.mark.benchmark(group="lookup")
+def test_filtered_lookup_over_many_registrations(benchmark):
+    """Named lookup against ten registrations of the same service type.
+
+    Isolates the registration scan and the filter call per candidate.
+    """
+    base, implementations = make_implementations(IMPLEMENTATION_COUNT)
+    container = Container()
+    for index, implementation in enumerate(implementations):
+        container.register(base, implementation, name=f"impl-{index}", lifespan=Lifespan.transient)
+
+    target = with_name(f"impl-{IMPLEMENTATION_COUNT - 1}")
+    benchmark(lambda: container.resolve(base, filter=target))
+
+
+@pytest.mark.benchmark(group="lookup")
+def test_decorator_chain(benchmark):
+    """Three decorators over one registration.
+
+    Isolates the decorator scan and the extra node per decorator.
+    """
+    base = make_class("Decorated")
+    container = Container()
+    container.register(base, lifespan=Lifespan.transient)
+    for index in range(DECORATOR_COUNT):
+        container.register_decorator(base, make_class(f"Decorator{index}", {"inner": base}))
+
+    benchmark(container.resolve, base)
+
+
+@pytest.mark.benchmark(group="scope")
+def test_scoped_resolve_in_root_scope(benchmark):
+    """Baseline for the scoped path, one level below the container."""
+    chain = make_chain(CHAIN_DEPTH)
+    container = Container()
+    container.register(chain[0], lifespan=Lifespan.scoped)
+    for cls in chain[1:]:
+        container.register(cls, lifespan=Lifespan.transient)
+
+    with container.new_scope() as scope:
+        benchmark(scope.resolve, chain[0])
+
+
+@pytest.mark.benchmark(group="scope")
+def test_scoped_resolve_in_nested_scope(benchmark):
+    """The same resolve three scopes deep.
+
+    Registration lookup walks to the parent scope for every dependency, so the
+    gap between this and the previous benchmark is the cost of scope nesting.
+    """
+    chain = make_chain(CHAIN_DEPTH)
+    container = Container()
+    container.register(chain[0], lifespan=Lifespan.scoped)
+    for cls in chain[1:]:
+        container.register(cls, lifespan=Lifespan.transient)
+
+    with container.new_scope() as outer, outer.new_scope() as middle, middle.new_scope() as inner:
+        benchmark(inner.resolve, chain[0])
+
+
+@pytest.mark.benchmark(group="async")
+def test_async_deep_transient_graph(benchmark, loop):
+    """The deep-graph benchmark through ``resolve_async``.
+
+    The sync and async paths are written separately, so both need cover to keep
+    them from drifting in performance as well as in behaviour.
+    """
+    chain = make_chain(CHAIN_DEPTH)
+    container = Container()
+    for cls in chain:
+        container.register(cls, lifespan=Lifespan.transient)
+
+    benchmark(lambda: loop.run_until_complete(container.resolve_async(chain[0])))
+
+
+@pytest.mark.benchmark(group="registration")
+def test_registration_of_many_types(benchmark):
+    """Registration cost for a hundred types.
+
+    Constructor introspection happens here rather than at resolve, so work moved
+    out of the resolve path should land in this number.
+    """
+    classes = [make_class(f"Reg{index}") for index in range(100)]
+
+    def register_all() -> None:
+        container = Container()
+        for cls in classes:
+            container.register(cls, lifespan=Lifespan.transient)
+
+    benchmark(register_all)

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: fixup lint format test docs-check ci typecheck pre-commit
+.PHONY: fixup lint format test docs-check ci typecheck pre-commit bench bench-save bench-compare
 
 
 install-deps:
@@ -36,7 +36,27 @@ format:
 
 test:
 	@echo "Running tests..."
-	@uv run pytest .
+	@uv run pytest
+
+
+bench:
+	@echo "Running benchmarks..."
+	@uv run --group bench pytest benchmarks --benchmark-only
+
+
+# Record the current revision as the baseline to compare later runs against.
+bench-save:
+	@echo "Saving benchmark baseline..."
+	@uv run --group bench pytest benchmarks --benchmark-only \
+		--benchmark-save=baseline --benchmark-save-data
+
+
+# Compare against the saved baseline. Fails if any min time regresses by more
+# than 50%. Only meaningful when both runs happened on the same machine.
+bench-compare:
+	@echo "Comparing benchmarks against baseline..."
+	@uv run --group bench pytest benchmarks --benchmark-only \
+		--benchmark-compare=0001_baseline --benchmark-compare-fail=min:50%
 
 docs-check:
 	@echo "Validating docs examples..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,10 @@ dev = [
     "pre-commit>=4.5.1,<5",
     "ty>=0.0.21,<1",
 ]
+bench = [
+    "pytest>=7.0.0,<8",
+    "pytest-benchmark>=4.0.0,<6",
+]
 
 [tool.uv]
 default-groups = [
@@ -121,10 +125,13 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]  # Ignore unused imports on init files
 "tests/**/*.py" = ["S101"]  # Allow assert usage on tests
+"benchmarks/**/*.py" = ["S101"]  # Allow assert usage on benchmarks
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+testpaths = ["tests"]
 
 [tool.coverage.run]
 branch = true
 source = ["clean_ioc", "tests"]
+omit = ["benchmarks/*"]

--- a/uv.lock
+++ b/uv.lock
@@ -188,6 +188,10 @@ fastapi = [
 ]
 
 [package.dev-dependencies]
+bench = [
+    { name = "pytest" },
+    { name = "pytest-benchmark" },
+]
 dev = [
     { name = "assertive" },
     { name = "fastapi" },
@@ -213,6 +217,10 @@ requires-dist = [
 provides-extras = ["fastapi"]
 
 [package.metadata.requires-dev]
+bench = [
+    { name = "pytest", specifier = ">=7.0.0,<8" },
+    { name = "pytest-benchmark", specifier = ">=4.0.0,<6" },
+]
 dev = [
     { name = "assertive", specifier = ">=1.6.1" },
     { name = "fastapi", specifier = ">=0.101.0,<0.102" },
@@ -834,6 +842,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1013,6 +1030,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/53/57663d99acaac2fcdafdc697e52a9b1b7d6fcf36616281ff9768a44e7ff3/pytest_asyncio-0.21.2.tar.gz", hash = "sha256:d67738fc232b94b326b9d060750beb16e0074210b98dd8b58a5239fa2a154f45", size = 30656, upload-time = "2024-04-29T13:23:24.738Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/ce/1e4b53c213dce25d6e8b163697fbce2d43799d76fa08eea6ad270451c370/pytest_asyncio-0.21.2-py3-none-any.whl", hash = "sha256:ab664c88bb7998f711d8039cacd4884da6430886ae8bbd4eded552ed2004f16b", size = 13368, upload-time = "2024-04-29T13:23:23.126Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/48/b79272b2b8938513a66a62204a0649ef730dcf6cb52c812f4dc4daa62cd5/pytest-benchmark-5.0.1.tar.gz", hash = "sha256:8138178618c85586ce056c70cc5e92f4283c2e6198e8422c2c825aeb3ace6afd", size = 337310, upload-time = "2024-10-30T01:12:16.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/e2/c0da4989a933d6bac364f215217c47de37d2f641953aa69a37b66efd6d1b/pytest_benchmark-5.0.1-py3-none-any.whl", hash = "sha256:d75fec4cbf0d4fd91e020f425ce2d845e9c127c21bae35e77c84db8ed84bfaa6", size = 44062, upload-time = "2024-10-30T01:12:13.716Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The library has no performance measurements. The eleven test modules cover behaviour well, but nothing measures time. Two things follow:

- A change to the resolve path cannot be shown to help.
- A regression passes CI unseen.

That makes any performance work on the container guesswork, so this adds the measurements first and changes no library code.

## What this adds

Eleven benchmarks under `benchmarks/`, each isolating one cost in the resolve path:

| Group | Benchmark | Isolates |
| --- | --- | --- |
| `single` | `test_transient_with_no_dependencies` | The floor of the resolve path |
| `single` | `test_singleton_already_cached` | A warm cache hit, so mostly registration lookup |
| `shape` | `test_deep_transient_graph` | Cost that scales with graph depth |
| `shape` | `test_wide_transient_graph` | Cost that scales with node count |
| `shape` | `test_collection_dependency` | `list[T]` resolution over many registrations |
| `lookup` | `test_filtered_lookup_over_many_registrations` | The registration scan and the filter call per candidate |
| `lookup` | `test_decorator_chain` | The decorator scan and the extra node per decorator |
| `scope` | `test_scoped_resolve_in_root_scope` | Baseline for the scoped path |
| `scope` | `test_scoped_resolve_in_nested_scope` | The added cost of scope nesting |
| `async` | `test_async_deep_transient_graph` | The separate async resolve path |
| `registration` | `test_registration_of_many_types` | Constructor introspection at registration |

Registration happens outside the measured callable everywhere except the last one, which measures registration on purpose. Work moved out of the resolve path has to land somewhere, and that is where it shows up.

Graph shapes are generated in `benchmarks/graphs.py` so that depth and width are parameters rather than constants baked into source. The generated classes are real classes with real `__init__` signatures, so the container introspects them exactly as it would introspect application code.

## Nothing changes for existing workflows

- `testpaths` is now `tests`, so plain `pytest` and `make test` collect the same 132 tests as before and never pick up benchmarks.
- `make test` runs `pytest` instead of `pytest .`, which is equivalent given `testpaths`.
- `pytest-benchmark` sits in a new `bench` dependency group, outside `default-groups`. A plain `uv sync` is unchanged.
- `make ci` is untouched and still passes.
- Benchmark results are gitignored, and `benchmarks/` is omitted from coverage.

## New targets

```
make bench           # run the suite and print the table
make bench-save      # record the current revision as the baseline
make bench-compare   # run again and fail if anything regressed by over 50%
```

The loop for a performance change is `make bench-save` on a clean tree, then the change, then `make bench-compare`.

## In CI

A new `Benchmarks` workflow runs on pull requests. It measures the merge base and the pull request head **on the same runner**, using the benchmark code from the pull request for both, so the only difference between the two runs is library code. Results upload as an artifact.

Two deliberate choices:

- It compares `min`, not `mean`. `min` is the least sensitive to the scheduling noise of a shared runner.
- The threshold is a loose 50%. This job is a guard against a change that makes resolution much slower. Smaller differences are noise on a shared runner and belong in a local `make bench-compare`.

## Baseline numbers

From one local run, for shape only. These are not a target and are not comparable to any other machine — the suite exists to compare two revisions on one machine.

| Benchmark | Median |
| --- | --- |
| `singleton_already_cached` | 6.5 µs |
| `scoped_resolve_in_root_scope` | 6.6 µs |
| `scoped_resolve_in_nested_scope` | 7.3 µs |
| `transient_with_no_dependencies` | 9.3 µs |
| `filtered_lookup_over_many_registrations` | 10.3 µs |
| `decorator_chain` | 17.2 µs |
| `collection_dependency` | 44.2 µs |
| `deep_transient_graph` (10 levels) | 49.9 µs |
| `async_deep_transient_graph` | 86.1 µs |
| `wide_transient_graph` (50 nodes) | 255 µs |
| `registration_of_many_types` (100) | 1.47 ms |

Two of these are worth a second look, and are the reason the suite is shaped this way:

- A warm singleton cache hit costs 6.5 µs. It should be close to a registration lookup and no more.
- Three levels of scope nesting adds only about 9%, which is less than I expected before measuring.

## Verified

- `make ci` passes: 132 tests, lint, format, `ty`, docs examples.
- `uv run pre-commit run --all-files` passes, `actionlint` included.
- `make bench` runs all eleven benchmarks.
- `make bench-save` then `make bench-compare` exits 0 on an unchanged tree, and exits non-zero when the threshold is tightened enough to trip, so the regression gate really does gate.

No library code changes, so no version bump and no `CHANGES.rst` entry.
